### PR TITLE
README.md: bunp to latest version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Shohei Ueda (peaceiris)
+Copyright (c) 2023 Matt Bailey (mattbailey)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ on:
 
 jobs:
   build-deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@master
       with:
         submodules: true
     - name: build
-      uses: mattbailey/actions-hugo@v0.57.2
+      uses: mattbailey/actions-hugo@v0.105.0
       if: github.event.deleted == false
       with:
         args: --gc --minify


### PR DESCRIPTION
This PR corrects `README.md` to that the workflow definition üoints to the latest released version `0.105.0`. It also corrects copyright information, I guess that's what appropriate here.